### PR TITLE
Added ASUS USB-AC53 Nano (ID 0b05:184c) for driver RTL8822B

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -241,6 +241,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE_AND_INTERFACE_INFO(0x7392, 0xB822, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, /* Edimax EW-7822ULC */
 	{USB_DEVICE_AND_INTERFACE_INFO(0x7392, 0xC822, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, /* Edimax EW-7822UTC */
 	{USB_DEVICE_AND_INTERFACE_INFO(0x0b05, 0x1841, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, /* ASUS AC1300 USB-AC55 B1 */
+	{USB_DEVICE_AND_INTERFACE_INFO(0x0b05, 0x184c, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, /* ASUS USB-AC53 Nano */
 #endif /* CONFIG_RTL8822B */
 
 #ifdef CONFIG_RTL8723D


### PR DESCRIPTION
Support for ASUS USB-AC53 Nano @ https://www.asus.com/us/Networking/USB-AC53-Nano/
```
Bus 003 Device 003: ID 0b05:184c ASUSTek Computer, Inc.
```

Tested on `5.0.0-19-generic #20-Ubuntu SMP Wed Jun 19 17:04:04 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux`