### PR TITLE
 add support linux-5.2.0

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1291,7 +1291,9 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+#if   LINUX_VERSION_CODE >= KERNEL_VERSION(5, 2, 0)
+	, struct net_device *sb_dev
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
 	, struct net_device *sb_dev
 	, select_queue_fallback_t fallback
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)


### PR DESCRIPTION
I corrected the arguments of the rtw_select_queue function.
I referred to this site.
https://elixir.bootlin.com/linux/latest/source/drivers/staging/rtl8188eu/os_dep/os_intfs.c#L247
https://elixir.bootlin.com/linux/v5.1.16/source/drivers/staging/rtl8188eu/os_dep/os_intfs.c#L247