### PR TITLE
set log level to _DRV_WARNING to decrease verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ CONFIG_RTW_WIFI_HAL = y
 CONFIG_RTW_DEBUG = y
 # default log level is _DRV_INFO_ = 4,
 # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
-CONFIG_RTW_LOG_LEVEL = 4
+CONFIG_RTW_LOG_LEVEL = 3
 ######################## Wake On Lan ##########################
 CONFIG_WOWLAN = n
 CONFIG_WAKEUP_TYPE = 0x7 #bit2: deauth, bit1: unicast, bit0: magic pkt.


### PR DESCRIPTION
The verbosity of the module is very high, this lowers it so that dmesg is not heavily polluted by messages coming from this driver.